### PR TITLE
Remove check on MachineSpecUpToDate condition

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -145,7 +145,7 @@ func (r *EtcdadmClusterReconciler) Reconcile(req ctrl.Request) (res ctrl.Result,
 		}
 
 		if reterr == nil && !res.Requeue && !(res.RequeueAfter > 0) && etcdCluster.ObjectMeta.DeletionTimestamp.IsZero() {
-			if !etcdCluster.Status.Ready && conditions.IsTrue(etcdCluster, etcdv1.EtcdMachinesSpecUpToDateCondition) {
+			if !etcdCluster.Status.Ready {
 				res = ctrl.Result{RequeueAfter: 20 * time.Second}
 			}
 		}


### PR DESCRIPTION
This check is not needed for etcdadmCluster to be reconciled during upgrade.
It also prevents the etcdadmCluster object from getting re-queued in case there
is no error but status.Ready is not set to true yet.