### PR TITLE
Save etcd http client separately per cluster

### DIFF
--- a/controllers/periodic_healthcheck.go
+++ b/controllers/periodic_healthcheck.go
@@ -3,8 +3,8 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -23,7 +23,7 @@ const (
 )
 
 type etcdHealthCheckConfig struct {
-	etcdHttpClient *http.Client
+	clusterToHttpClient sync.Map
 }
 
 type etcdadmClusterMemberHealthConfig struct {


### PR DESCRIPTION
Each etcdadmCluster object needs to use a separate http client, since
this client contains the etcd cluster's ca cert and client cert-key pair.
This commit replaces the field containing http client with a sync.Map
where key is the cluster UID and value is the etcd http client.
It uses golang's sync Map because as per docs:
* The sync.Map type is optimized for when the entry for a given key is only ever
 written once but read many times
* Use of a sync.Map may significantly reduce lock contention compared to a
Go map paired with a separate Mutex or RWMutex.
https://pkg.go.dev/sync#Map