### PR TITLE
Delete owned machines when etcdadmcluster is deleted

### DIFF
--- a/api/v1beta1/etcdadmcluster_types.go
+++ b/api/v1beta1/etcdadmcluster_types.go
@@ -25,6 +25,10 @@ import (
 
 const (
 	UpgradeInProgressAnnotation = "etcdcluster.cluster.x-k8s.io/upgrading"
+
+	// EtcdadmClusterFinalizer is the finalizer applied to EtcdadmCluster resources
+	// by its managing controller.
+	EtcdadmClusterFinalizer = "etcdcluster.cluster.x-k8s.io"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!


### PR DESCRIPTION
The etcdadmCluster controller manages the EtcdadmCluster object and its owned Machines by:
1. Creating a new Machine per etcd member
2. Adding/removing machines during upgrade
It is similar in behavior to how he KubeadmControlPlane controller manages the Machine object.

When the EtcdadmCluster object is deleted, the controller should also remove the owned/managed Machines. The[ KCP controller](https://github.com/kubernetes-sigs/cluster-api/blob/v1.0.1/controlplane/kubeadm/controllers/controller.go#L399) does this by adding a finalizer on the KCP object when it is created, deleting the owned machines when the KCP.deletionTimestamp is set, and removing the finalizer on KCP only after the owned machines have been deleted.
This PR adds the same logic to the etcdadmCluster controller.