### PR TITLE
Add endpoints available condition

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -39,4 +39,10 @@ const (
 
 	// EtcdClusterHasOutdatedMembersReason shows that some of the etcd members are out-of-date
 	EtcdClusterHasOutdatedMembersReason = "EtcdClusterHasOutdatedMachines"
+
+	// EtcdEndpointsAvailable shows that all endpoints of the etcd cluster passed healthcheck and are available
+	EtcdEndpointsAvailable = "EtcdEndpointsAvailable"
+
+	// WaitingForEtcdadmEndpointsToPassHealthcheckReason shows that some of the etcd members are not ready yet
+	WaitingForEtcdadmEndpointsToPassHealthcheckReason = "WaitingForEtcdadmEndpointsToPassHealthcheck"
 )

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,7 +33,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: ${ETCDADM_CONTROLLER_IMAGE}
+        image: "mrajashree/etcdadm-controller:latest"
         name: manager
         resources:
           limits:

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -283,6 +283,7 @@ func (r *EtcdadmClusterReconciler) reconcile(ctx context.Context, etcdCluster *e
 		// Create first etcd machine to run etcdadm init
 		log.Info("Initializing etcd cluster", "Desired", desiredReplicas, "Existing", numCurrentMachines)
 		conditions.MarkFalse(etcdCluster, etcdv1.InitializedCondition, etcdv1.WaitingForEtcdadmInitReason, clusterv1.ConditionSeverityInfo, "")
+		conditions.MarkFalse(etcdCluster, etcdv1.EtcdEndpointsAvailable, etcdv1.WaitingForEtcdadmEndpointsToPassHealthcheckReason, clusterv1.ConditionSeverityInfo, "")
 		return r.intializeEtcdCluster(ctx, etcdCluster, cluster, ep)
 	case numCurrentMachines > 0 && conditions.IsFalse(etcdCluster, etcdv1.InitializedCondition):
 		// as soon as first etcd machine is up, etcdadm init would be run on it to initialize the etcd cluster, update the condition
@@ -371,6 +372,7 @@ func patchEtcdCluster(ctx context.Context, patchHelper *patch.Helper, ec *etcdv1
 			etcdv1.EtcdClusterResizeCompleted,
 			etcdv1.InitializedCondition,
 			etcdv1.EtcdClusterHasNoOutdatedMembersCondition,
+			etcdv1.EtcdEndpointsAvailable,
 		),
 	)
 
@@ -386,6 +388,7 @@ func patchEtcdCluster(ctx context.Context, patchHelper *patch.Helper, ec *etcdv1
 			etcdv1.EtcdClusterResizeCompleted,
 			etcdv1.InitializedCondition,
 			etcdv1.EtcdClusterHasNoOutdatedMembersCondition,
+			etcdv1.EtcdEndpointsAvailable,
 		}},
 		patch.WithStatusObservedGeneration{},
 	)

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -70,6 +70,7 @@ func (r *EtcdadmClusterReconciler) updateStatus(ctx context.Context, ec *etcdv1.
 	// etcd ready when all machines have address set
 	ec.Status.Ready = true
 	ec.Status.Endpoints = strings.Join(endpoints, ",")
+	conditions.MarkTrue(ec, etcdv1.EtcdEndpointsAvailable)
 	// set creationComplete to true, this is only set once after the first set of endpoints are ready and never unset, to indicate that the cluster has been created
 	ec.Status.CreationComplete = true
 


### PR DESCRIPTION
Bug found when testing: https://github.com/aws/eks-anywhere/pull/1251

The Ready condition on EtcdadmCluster is set as an aggregate of all conditions
set on the object. This is the logic that all CAPI controllers follow for the
Ready condition of the CRDs they manage.
During cluster creation, Initialized is the last condition that gets set on the
etcdadmCluster object. It gets set to true when the first etcd member is active.
So the Ready condition also gets set to true during cluster creation once the
Initialized condition becomes true. 

This works fine for infrastructure providers like CAPV/CAPD/CAPC where the infra
machines do not take too long to get provisioned.
But for the tinkerbell provider, the time difference between the first etcd member
being active and all etcd endpoints passing healthcheck is significant (~7 minutes
as opposed to < 1min for other infra providers).
This does not affect standalone CAPI cluster creation with external etcd. But this
does impact EKS Anywhere cluster creation due to timeouts related to kubeconfig secret.
EKS Anywhere waits on the etcd ready condition to be true before it starts fetching the kubeconfig secret.
But since etcd ready condition becomes true as soon as Initialized becomes true, eks anywhere does
not wait long enough for all etcd endpoints to be active, and starts waiting on kubeconfig secret.
Since KCP provisioning doesn't start till all etcd endpoints are ready, kubeconfig does not get
created in time and eks-anywhere times out. 

This commit adds another condition on the EtcdadmCluster object
called `EtcdEndpointsAvailable` which becomes true only when all endpoints
pass healthcheck. It gets set to false before etcd cluster provisioning starts,
so that Ready condition as an aggregate will hold the value of `false` till all
endpoints are ready.

Tested: 
CAPV cluster creation and deletion
Upgrading an existing CAPV cluster to use this commit
CAPT cluster creation and deletion