### PR TITLE
Fixes for reconciling deleted etcd machines/VMs

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -210,8 +210,8 @@ func (r *EtcdadmClusterReconciler) reconcile(ctx context.Context, etcdCluster *e
 			outdatedMachines := etcdMachines.Difference(ownedMachines)
 			log.Info(fmt.Sprintf("Controlplane upgrade has completed, deleting older outdated etcd members: %v", outdatedMachines.Names()))
 			for _, outdatedMachine := range outdatedMachines {
-				err := r.removeEtcdMember(ctx, etcdCluster, cluster, ep, outdatedMachine)
-				if err != nil {
+				outdatedMachineAddress := getEtcdMachineAddress(outdatedMachine)
+				if err := r.removeEtcdMachine(ctx, etcdCluster, cluster, outdatedMachine, outdatedMachineAddress); err != nil {
 					return ctrl.Result{}, err
 				}
 			}


### PR DESCRIPTION
* The periodic healthcheck loop skipped deletion of etcd members
if corresponding machine doesn't exist. This commit proceeds with the removal
of the etcd member from the cluster.
* Etcdadm-controller detects changes in the endpoints field and updates the
Secret containing etcd address accordingly.
* During member removal, the controller checked if the Secret containing etcd
init address corresponds to an existing etcd machine or needs to be updated.
Since the Secret will now contain etcd client URLs of all endpoints, this check
is no longer needed, since etcdadm can proceed with join even if at least 1 of the
endpoints is active. In case of an upgrade post scale down, 2 members would be
active. This is in fact better than earlier, because etcdadm uses these client URLs
to generate the etcd client. And having 2 active members over 1 better guarantees
the generation of etcd client and communicating with the cluster.