### PR TITLE
Set machine's version with etcd version

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -149,6 +149,7 @@ func (r *EtcdadmClusterReconciler) generateMachine(ctx context.Context, ec *etcd
 				ConfigRef: bootstrapRef,
 			},
 			FailureDomain: failureDomain,
+			Version:       &ec.Spec.EtcdadmConfigSpec.CloudInitConfig.Version,
 		},
 	}
 	if err := r.Client.Create(ctx, machine); err != nil {


### PR DESCRIPTION
With regarding to this issue (https://github.com/aws/eks-anywhere/issues/1889) about not showing version information for the etcd machines, I added the etcd version into the machine version. With this fix, the etcd version is shown. 

```
NAMESPACE     NAME                            CLUSTER   NODENAME   PROVIDERID                                           PHASE          AGE   VERSION
eksa-system   wk-mgmt-etcd-285vf              wk-mgmt              cloudstack:///480718ac-4e61-4f2b-bb9e-2d25e56b3f30   Running        67s   v3.4.18
eksa-system   wk-mgmt-gr5x5                   wk-mgmt                                                                   Provisioning   4s    v1.21.9-eks-1-21-12
eksa-system   wk-mgmt-md-0-5bddc4f978-jmbgg   wk-mgmt                                                                   Pending        77s   v1.21.9-eks-1-21-12
```