### PR TITLE
Increase the resource requests and limits to 50mi/100mi from 20mi/30mi

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,9 +38,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager

--- a/etcdadm.yaml
+++ b/etcdadm.yaml
@@ -510,9 +510,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       serviceAccountName: etcdadm-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
When created one management cluster with 1 etcd machine and one workload cluster with 1 etcd machine the memory usage of etcdadm controller manager container uses 25Mi. When increasing the number of etcd machines of the workload cluster to 3 and 5 the memory usages were increased slightly to 26Mi. Since the memory usage with the low number of etcd machine is very close to the memory limit I want to increase the resource request and limits to 50Mi/100Mi.